### PR TITLE
Correct typo in number of colors to generate

### DIFF
--- a/wal
+++ b/wal
@@ -81,7 +81,7 @@ get_colors() {
     if [[ -f "$cache_file" ]]; then
         colors=($(< "$cache_file"))
     else
-        colors=($(convert "${wal}"  +dither -colors 18 -unique-colors txt:- | grep -E -o " \#.{6}"))
+        colors=($(convert "${wal}"  +dither -colors 16 -unique-colors txt:- | grep -E -o " \#.{6}"))
 
         # If imagemagick finds less than 16 colors, use a larger source number of colors.
         while (( "${#colors[@]}" <= 15 )); do


### PR DESCRIPTION
I was puzzled that regular ```wal``` and wpgtk generate different color schemes for the same image and this is the reason.